### PR TITLE
[43] Add fields for patents

### DIFF
--- a/ai_genomics/analysis/data_scoping/patent_data/search_evaluation.md
+++ b/ai_genomics/analysis/data_scoping/patent_data/search_evaluation.md
@@ -1,0 +1,64 @@
+# Patent Search Evaluation
+
+## Approach 1
+
+### Collection
+
+Patent publication numbers (`doc_id`) were selected from USPTO AI data by filtering for those which are patents (`patent_flag == 1`) and those which are predicted to relate to AI (`predict50_any_ai == 1`). These publication numbers were then used to query a database which is a subset of patents with IPC or CPC codes relating to genomics. These codes were identified using simple partial keyword matching. This resulted in ~8.5k patents.
+
+### Evaluation
+
+One hundred examples were randomly sampled from the data and inspected to determine whether they related to AI or genomics (`outputs/data/patents/ai_genomics_patents_verified.csv`). Their title and abstract were read to see if they contained content relating to those subjects and binary indicators were used to denote whether or not this was the case. In some cases, the title and abstract were ambiguous, and the patent was searched for on Google Patents and inspected in further detail. This was typically done by skim reading and searching for keywords belonging to each topic (e.g. gene, genetic, dna, nucleic, machine learning, classify, cluster, detect). The results should be interpreted with some degree of error as it is often quite difficult to identify whether a patent relates to the topics of interest due to vague language, non-expert knowledge in genomics and the length of some patents.
+
+The table below shows the counts of projects in the sample that are and are not related to AI and genomics. It is immediately clear that there are many projects that are not related to the two subjects - 66 are related to only one of them, and 7 are related to neither. The content of the titles, abstracts and patent texts suggests some reasons as to why this may be.
+
+|        | Not Genomics | Genomics |
+| :----- | -----------: | -------: |
+| Not AI |            7 |       41 |
+| AI     |           25 |       27 |
+
+One reason is that the definitions of AI and genomics are overly broad. The current filtering mechanism includes patents predicted to relate to machine learning, natural language processing, computer vision, speech, knowledge processing, AI hardware, evolutionary computation, and planning and control. Several patents covered topics such as new silicon chip architectures and automated manufacturing processes, which are more tangentially related to enabling and employing AI. In addition, there were several patents that covered genetic algorithms, but did not touch upon genomics. Upon closer inspection, the patent codes for these documents often referred to 'genetic computing'.
+
+Another possible reason is poor classification of AI topics in the USPTO data. Several examples in the dataset discussed topics that contained vocabulary associated with AI and machine learning but that were being used in other contexts. For example, one patent referred to 'clustering' several times but was in fact referring to the physial aggregation of biological particles. In several cases, the word 'data' is used throughout, but the methods described to use the data are not based on machine learning. There were also some patents that used conventional computer vision, reliant on conventional image processing rather than AI-like technologies. It is not immediately clear which part of the pipeline used to predict AI patents that these errors originate from.
+
+In addition to counting the number of patents that related to our two areas of interest, the number of patents that had ambiguous tites or abstracts were recorded. We can see that in the minority of cases where Only 27 that are both AI and genomics. 66 are only one and 7 are neither. This suggests that we should be careful when performing text analysis (e.g. topic modelling) on the patent abstracts as they do not reveal all of the information about the patent that might be most relevant for our purpose.
+
+|        | Not Genomics | Genomics |
+| :----- | -----------: | -------: |
+| Not AI |            0 |       21 |
+| AI     |           11 |       23 |
+
+### Suggested improvements
+
+First we should refine the IPC/CPC patent codes used for our definition of genomics. This could be done manually (e.g. by pruning topics such as 'genetic algorithms') or by using a more sophisticated for creating the definition (e.g. embeddings instead of keywords). As the first method is simpler, this should be attempted first. We should also ensure the IPC/CPC codes used are as expansive as possible to make sure that we also capture genomics related topics that might not have appeard in the results from this query. A combined keyword search and manual filtering approach is probably suitable for this.
+
+Second, we should also refine the columns used from the USPTO data for our definition of AI. We could drop AI hardware, planning and control and knowledge processing to be left with machine learning, natural language processing, computer vision evolutionary computation and speech.
+
+## Approach 2
+
+### Collection
+
+The same approach as above is used, except that the USPTO data is filtered by specific AI flags, rather than for all 'AI related' work. These are machine learning, evolutionary computation, computer vision, speech and natural language processing (using the columns prefixed by `predict50_`). This yielded ~3.5k patents.
+
+### Evaluation
+
+In this case, a random sample of 50 patents (`outputs/data/patents/ai_genomics_patents_ml_evo_cv_nlp_sp_verified.csv`) were evaluated in the same way described above. As a proportion, we see improved recall on patents related to AI, but a decrease in those related to genomics. Annecdotally, there is a high representation of patents describing genetic algorithms, but with no relationship to genomics.
+
+There is also some noise in the USPTO data resulting in false positives, which contribute to the 20 patents assessed as _Not AI_.
+
+|        | Not Genomics | Genomics |
+| :----- | -----------: | -------: |
+| Not AI |            6 |       14 |
+| AI     |           19 |       11 |
+
+### Suggested improvements
+
+- The next step would be to expand and refine the patent code definition of genomics and re-run the evaluation before advancing on to any more sophisticated methods.
+- Another step would be to further refine the data in the USPTO AI patents by setting a higher threshold on the prediction probability. The `predict50_` fields set a minimum threshold of 0.5 on the prediction probability for a patent to be classed as AI related. Setting this higher (e.g. 0.9) would eliminate some false positives. A larger sample of labelled data would be needed to determine whether the benefits gained in precision would offset the loss in recall.
+
+## Next steps
+
+- [ ] Expand and refine genomics patent codes.
+- [ ] Explore the possibility of creating an AI patent code list to complement the predictions in the USPTO data.
+- [ ] Investigate the distribution of prediction probabilities in the USPTO data for manually labelled patents to determine a new minimum threshold for inclusion.
+- [ ] Explore the distribution of patent codes across the resultant dataset.

--- a/ai_genomics/getters/patents.py
+++ b/ai_genomics/getters/patents.py
@@ -1,49 +1,33 @@
 from fnmatch import fnmatch
-from ai_genomics import bucket_name
+from ai_genomics import bucket_name as BUCKET_NAME
 from ai_genomics.getters.data_getters import load_s3_data, s3, get_s3_dir_files
 import pandas as pd
-from boto3_type_annotations.s3 import ServiceResource
 
 
-def get_ai_genomics_patent_num_csv_s3_dirs(
-    s3: ServiceResource = s3, bucket_name: str = bucket_name
-) -> list:
-    """Gets a list of S3 directories containing csvs of AI in genomics
+def get_ai_genomics_patent_num_csv_s3_dirs() -> list:
+    """Returns a list of S3 directories containing csvs of AI in genomics
     patent application numbers
-
-    Args:
-        s3: S3 boto resource
-        bucket_name: S3 bucket name
-
-    Returns:
-        List of S3 directories containing csvs of AI in genomics patent
-            application numbers
     """
     return [
         path
         for path in get_s3_dir_files(
             s3,
-            bucket_name,
+            BUCKET_NAME,
             "outputs/patent_data/ai_genomics_id_chunks/golden-shine-355915_genomics_85_chunksize/",
         )
         if fnmatch(path, "*.csv")
     ]
 
 
-def get_ai_genomics_patent_app_numbers(bucket_name: str = bucket_name) -> list:
+def get_ai_genomics_patent_app_numbers() -> list:
     """Loads chunks of AI in genomics patent application numbers
     from S3. Combines chunks together into one dataframe.
-
-    Args:
-        bucket_name: S3 bucket name
-
-    Returns:
-        List of AI in genomics patent application numbers
+    Returns a list of AI in genomics patent application numbers.
     """
     return list(
         pd.concat(
             [
-                load_s3_data(bucket_name, csv)
+                load_s3_data(BUCKET_NAME, csv)
                 for csv in get_ai_genomics_patent_num_csv_s3_dirs()
             ]
         )
@@ -52,19 +36,10 @@ def get_ai_genomics_patent_app_numbers(bucket_name: str = bucket_name) -> list:
     )
 
 
-def get_ai_genomics_patents_with_fields(
-    bucket_name: str = bucket_name,
-    file_name: str = "inputs/patent_data/processed_patent_data/ai_genomics_patents.csv",
-) -> pd.DataFrame:
-    """From S3 loads AI in genomics patents with fields such as applicaiton number,
-    patent abstract, publication date, filing date.
-
-
-    Args:
-        bucket_name: S3 bucket name
-        file_name: S3 path to filename
-
-    Returns:
-        Dataframe of AI in genomics patents
+def get_ai_genomics_patents_with_fields() -> pd.DataFrame:
+    """From S3 loads dataframe of AI in genomics patents with fields
+    such as applicaiton number, patent abstract, publication date, filing date.
     """
-    return load_s3_data(bucket_name, file_name)
+    return load_s3_data(
+        BUCKET_NAME, "inputs/patent_data/processed_patent_data/ai_genomics_patents.csv"
+    )

--- a/ai_genomics/getters/patents.py
+++ b/ai_genomics/getters/patents.py
@@ -4,9 +4,9 @@ from ai_genomics.getters.data_getters import load_s3_data, s3, get_s3_dir_files
 import pandas as pd
 
 
-def get_ai_genomics_patent_num_csv_s3_dirs() -> list:
+def get_ai_genomics_patents_csv_s3_dirs() -> list:
     """Returns a list of S3 directories containing csvs of AI in genomics
-    patent application numbers
+    patents
     """
     return [
         path
@@ -19,19 +19,19 @@ def get_ai_genomics_patent_num_csv_s3_dirs() -> list:
     ]
 
 
-def get_ai_genomics_patent_app_numbers() -> list:
-    """Loads chunks of AI in genomics patent application numbers
+def get_ai_genomics_patent_pub_numbers() -> list:
+    """Loads chunks of AI in genomics patent publication numbers
     from S3. Combines chunks together into one dataframe.
-    Returns a list of AI in genomics patent application numbers.
+    Returns a list of AI in genomics patent publication numbers.
     """
     return list(
         pd.concat(
             [
                 load_s3_data(BUCKET_NAME, csv)
-                for csv in get_ai_genomics_patent_num_csv_s3_dirs()
+                for csv in get_ai_genomics_patents_csv_s3_dirs()
             ]
         )
-        .drop_duplicates()["application_number"]
+        .drop_duplicates()["publication_number"]
         .values
     )
 

--- a/ai_genomics/getters/patents.py
+++ b/ai_genomics/getters/patents.py
@@ -1,0 +1,52 @@
+from fnmatch import fnmatch
+from ai_genomics import bucket_name
+from ai_genomics.getters.data_getters import load_s3_data, s3, get_s3_dir_files
+import pandas as pd
+from boto3_type_annotations.s3 import ServiceResource
+
+
+def get_ai_genomics_patent_num_csv_s3_dirs(
+    s3: ServiceResource = s3, bucket_name: str = bucket_name
+) -> list:
+    """Gets a list of S3 directories containing csvs of AI in genomics
+    patent application numbers
+
+    Args:
+        s3: S3 boto resource
+        bucket_name: S3 bucket name
+
+    Returns:
+        List of S3 directories containing csvs of AI in genomics patent
+            application numbers
+    """
+    return [
+        path
+        for path in get_s3_dir_files(
+            s3,
+            bucket_name,
+            "outputs/patent_data/ai_genomics_id_chunks/golden-shine-355915_genomics_85_chunksize/",
+        )
+        if fnmatch(path, "*.csv")
+    ]
+
+
+def get_ai_genomics_patent_app_numbers(bucket_name: str = bucket_name) -> list:
+    """Loads chunks of AI in genomics patent application numbers
+    from S3. Combines chunks together into one dataframe.
+
+    Args:
+        bucket_name: S3 bucket name
+
+    Returns:
+        List of AI in genomics patent application numbers
+    """
+    return list(
+        pd.concat(
+            [
+                load_s3_data(bucket_name, csv)
+                for csv in get_ai_genomics_patent_num_csv_s3_dirs()
+            ]
+        )
+        .drop_duplicates()["application_number"]
+        .values
+    )

--- a/ai_genomics/getters/patents.py
+++ b/ai_genomics/getters/patents.py
@@ -50,3 +50,21 @@ def get_ai_genomics_patent_app_numbers(bucket_name: str = bucket_name) -> list:
         .drop_duplicates()["application_number"]
         .values
     )
+
+
+def get_ai_genomics_patents_with_fields(
+    bucket_name: str = bucket_name,
+    file_name: str = "inputs/patent_data/processed_patent_data/ai_genomics_patents.csv",
+) -> pd.DataFrame:
+    """From S3 loads AI in genomics patents with fields such as applicaiton number,
+    patent abstract, publication date, filing date.
+
+
+    Args:
+        bucket_name: S3 bucket name
+        file_name: S3 path to filename
+
+    Returns:
+        Dataframe of AI in genomics patents
+    """
+    return load_s3_data(bucket_name, file_name)

--- a/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
+++ b/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
@@ -5,7 +5,7 @@ from ai_genomics.getters.data_getters import save_to_s3, s3
 from ai_genomics import bucket_name as BUCKET_NAME
 
 SELECT_COLS = (
-    "application_number, country_code, title_localized, abstract_localized, "
+    "application_number, publication_number, country_code, title_localized, abstract_localized, "
     "publication_date, filing_date, grant_date, priority_date, inventor, "
     "inventor_harmonized, assignee, assignee_harmonized, ipc, cpc, entity_status"
 )

--- a/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
+++ b/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
@@ -1,8 +1,10 @@
 from ai_genomics.utils.patent_data.get_ai_genomics_patents_utils import est_conn
 from ai_genomics.getters.patents import get_ai_genomics_patent_app_numbers
-from google.cloud import bigquery
 from ai_genomics.getters.data_getters import save_to_s3, s3
 from ai_genomics import bucket_name as BUCKET_NAME
+from google.cloud import bigquery
+import pandas as pd
+import numpy as np
 
 SELECT_COLS = (
     "application_number, publication_number, country_code, title_localized, abstract_localized, "
@@ -11,6 +13,7 @@ SELECT_COLS = (
 )
 AI_GENOMICS_PATENT_APP_NUMBERS = get_ai_genomics_patent_app_numbers()
 S3_SAVE_FILENAME = "/inputs/patent_data/processed_patent_data/ai_genomics_patents.csv"
+DATE_COLS = ["publication_date", "grant_date", "filing_date", "priority_date"]
 
 
 def make_ai_genomics_query(select_cols: str = SELECT_COLS) -> str:
@@ -37,9 +40,33 @@ def make_bigquery_job_config(
     )
 
 
+def replace_missing_values_with_nans(ai_genomics_patents: pd.DataFrame) -> pd.DataFrame:
+    """Replace missing values in the AI in
+    genomics patents dataset with NaNs"""
+    return ai_genomics_patents.replace(
+        {date_col: 0 for date_col in DATE_COLS},
+        np.nan,
+    ).mask(ai_genomics_patents.applymap(str).eq("[]"))
+
+
+def convert_date_columns_to_datetime(ai_genomics_patents: pd.DataFrame) -> pd.DataFrame:
+    """Convert date columns to datetime format
+    in the AI in genomics patents dataset"""
+    for col in DATE_COLS:
+        ai_genomics_patents[col] = pd.to_datetime(
+            ai_genomics_patents[col], format="%Y%m%d"
+        )
+    return ai_genomics_patents
+
+
 if __name__ == "__main__":
     client = est_conn()
     query = make_ai_genomics_query()
     job_config = make_bigquery_job_config()
-    ai_genomics_patents_info = client.query(query, job_config).to_dataframe()
+    ai_genomics_patents_info = (
+        client.query(query, job_config)
+        .to_dataframe()
+        .pipe(replace_missing_values_with_nans)
+        .pipe(convert_date_columns_to_datetime)
+    )
     save_to_s3(s3, BUCKET_NAME, ai_genomics_patents_info, S3_SAVE_FILENAME)

--- a/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
+++ b/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
@@ -2,7 +2,7 @@ from ai_genomics.utils.patent_data.get_ai_genomics_patents_utils import est_conn
 from ai_genomics.getters.patents import get_ai_genomics_patent_app_numbers
 from google.cloud import bigquery
 from ai_genomics.getters.data_getters import save_to_s3, s3
-from ai_genomics import bucket_name
+from ai_genomics import bucket_name as BUCKET_NAME
 
 SELECT_COLS = (
     "application_number, country_code, title_localized, abstract_localized, "
@@ -42,4 +42,4 @@ if __name__ == "__main__":
     query = make_ai_genomics_query()
     job_config = make_bigquery_job_config()
     ai_genomics_patents_info = client.query(query, job_config).to_dataframe()
-    save_to_s3(s3, bucket_name, ai_genomics_patents_info, S3_SAVE_FILENAME)
+    save_to_s3(s3, BUCKET_NAME, ai_genomics_patents_info, S3_SAVE_FILENAME)

--- a/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
+++ b/ai_genomics/pipeline/patent_data/add_fields_to_patents.py
@@ -1,5 +1,5 @@
 from ai_genomics.utils.patent_data.get_ai_genomics_patents_utils import est_conn
-from ai_genomics.getters.patents import get_ai_genomics_patent_app_numbers
+from ai_genomics.getters.patents import get_ai_genomics_patent_pub_numbers
 from ai_genomics.getters.data_getters import save_to_s3, s3
 from ai_genomics import bucket_name as BUCKET_NAME
 from google.cloud import bigquery
@@ -11,7 +11,7 @@ SELECT_COLS = (
     "publication_date, filing_date, grant_date, priority_date, inventor, "
     "inventor_harmonized, assignee, assignee_harmonized, ipc, cpc, entity_status"
 )
-AI_GENOMICS_PATENT_APP_NUMBERS = get_ai_genomics_patent_app_numbers()
+AI_GENOMICS_PATENT_PUB_NUMBERS = get_ai_genomics_patent_pub_numbers()
 S3_SAVE_FILENAME = "/inputs/patent_data/processed_patent_data/ai_genomics_patents.csv"
 DATE_COLS = ["publication_date", "grant_date", "filing_date", "priority_date"]
 
@@ -20,21 +20,21 @@ def make_ai_genomics_query(select_cols: str = SELECT_COLS) -> str:
     """Make AI in genomics BigQuery sql query"""
     return (
         f"SELECT {select_cols} FROM `patents-public-data.patents.publications` "
-        "WHERE application_number IN UNNEST(@ai_genomics_patent_app_numbers)"
+        "WHERE publication_number IN UNNEST(@ai_genomics_patent_pub_numbers)"
     )
 
 
 def make_bigquery_job_config(
-    ai_genomics_patent_app_numbers: list = AI_GENOMICS_PATENT_APP_NUMBERS,
+    ai_genomics_patent_pub_numbers: list = AI_GENOMICS_PATENT_PUB_NUMBERS,
 ) -> bigquery.job.query.QueryJobConfig:
     """Make BigQuery job config. This enables a parameter to be fed
     into the query to overcome query length limits"""
     return bigquery.QueryJobConfig(
         query_parameters=[
             bigquery.ArrayQueryParameter(
-                "ai_genomics_patent_app_numbers",
+                "ai_genomics_patent_pub_numbers",
                 "STRING",
-                ai_genomics_patent_app_numbers,
+                ai_genomics_patent_pub_numbers,
             ),
         ]
     )

--- a/ai_genomics/pipeline/patent_data/cleaning.py
+++ b/ai_genomics/pipeline/patent_data/cleaning.py
@@ -1,0 +1,72 @@
+"""ai_genomics/pipeline/patent_data/cleaning.py
+
+Functions for cleaning patent data from Google Patents.
+"""
+
+import json
+from toolz.functoolz import pipe
+
+from typing import List, Union
+
+from ai_genomics.utils.text import contains_non_ascii
+
+
+def parse_patent_record(record_raw: str) -> dict:
+    """Parses a JSON-like string from patent data fields that have NDJSON
+    format. Includes fields like `title_localized`, `abstract_localized` and
+    `inventor_harmonized`.
+
+    Args:
+        record: JSON-like string of a single record from a patent field.
+
+    Returns:
+        Dictionary of record.
+    """
+    if len(record_raw) > 5:  # handle empty records
+        return pipe(
+            record_raw,
+            lambda r: r.replace("'", '"'),
+            lambda r: r.replace("False", '"False"'),
+            lambda r: r.replace("True", '"True"'),
+            json.loads,
+        )
+    else:
+        return None
+
+
+def preprocess_records(records_raw: str) -> List[str]:
+    """Splits ndjson-like field (e.g. abstract_localized, title_localized) into
+    list of dict-like strings.
+    """
+    return pipe(records_raw, lambda rs: rs[1:-1], lambda rs: rs.split("\n"))
+
+
+def extract_english_record(records_raw: str) -> Union[str, None]:
+    """Extracts English text from a record if present. Where possible, texts
+    with a full character set are selected, otherwise the text returned is
+    ASCII only.
+
+    Args:
+        records_raw: NDJSON-like field from Google Patents that contains identical
+            entries in different languages. This might include:
+                - title_localized
+                - abstract_localized
+
+    Returns:
+        text: The English text. If none available, then None is returned.
+    """
+
+    text = None
+
+    records = preprocess_records(records_raw)
+    for record in records:
+        record = parse_patent_record(record)
+        if record is None:
+            return record
+
+        if (record["language"] == "en") and (contains_non_ascii(record["text"])):
+            return record["text"]
+        elif (record["language"] == "en") and not (contains_non_ascii(record["text"])):
+            text = record["text"]
+
+    return text

--- a/ai_genomics/pipeline/patent_data/evaluation_sample.py
+++ b/ai_genomics/pipeline/patent_data/evaluation_sample.py
@@ -1,6 +1,7 @@
 """ai_genomics/pipeline/patent_data/evaluation_sample.py
 
-Tool for exporting a sample of
+Tools for reporting on manually labelled patents as
+belonging to categories of AI and genomics (or not).
 """
 
 import click

--- a/ai_genomics/pipeline/patent_data/evaluation_sample.py
+++ b/ai_genomics/pipeline/patent_data/evaluation_sample.py
@@ -1,0 +1,111 @@
+"""ai_genomics/pipeline/patent_data/evaluation_sample.py
+
+Tool for exporting a sample of
+"""
+
+import click
+import pandas as pd
+from pathlib import PosixPath
+
+from ai_genomics import PROJECT_DIR
+
+
+def ai_genomics_counts(
+    labelled_patents: pd.DataFrame,
+    percent: bool = True,
+) -> str:
+    """Creates a 2x2 markdown table matrix of the count or percentage of
+    patents that have been manually labelled as belonging to the
+    categories of AI and genomics (or not).
+
+    Args:
+        labelled_patents: DataFrame with columns `abstract_en` (str), `is_ai`
+            (bool) and `is_genomics` (bool).
+        percent: If True, returns the percentage of patents in each category.
+            Defaults to True.
+
+    Returns:
+        Markdown string of count/percentage table.
+    """
+    labelled_patents = labelled_patents.dropna(subset=["is_ai"])
+    cat_counts = pd.pivot_table(
+        labelled_patents, index="is_ai", columns="is_genomics", aggfunc="count"
+    )["abstract_en"].rename(
+        columns={0: "Not Genomics", 1: "Genomics"},
+        index={0: "Not AI", 1: "AI"},
+    )
+
+    if percent:
+        cat_counts = (cat_counts / labelled_patents.shape[0]) * 100
+        cat_counts = cat_counts.round(2)
+
+    cat_counts.index.name = None
+    cat_counts.columns.name = None
+
+    return cat_counts.to_markdown()
+
+
+def ai_genomics_read_full_patent(
+    labelled_patents: pd.DataFrame,
+    percent: bool = True,
+) -> str:
+    """Creates a 2x2 markdown table matrix of the count or percentage of
+    patents that have been manually labelled as belonging to the
+    categories of AI and genomics (or not) AND whose full texts were read
+    to ascertain which category they belonged to.
+
+    Args:
+        labelled_patents: DataFrame with columns `read_full_patent` (bool),
+        `is_ai` (bool) and `is_genomics` (bool).
+        percent: If True, returns the percentage of patents in each category.
+            Defaults to True.
+
+    Returns:
+        Markdown string of count/percentage table.
+    """
+    labelled_patents = labelled_patents.dropna(subset=["is_ai"])
+    cat_counts = pd.pivot_table(
+        labelled_patents,
+        index="is_ai",
+        columns="is_genomics",
+        values="read_full_patent",
+        aggfunc="sum",
+    ).rename(
+        columns={0: "Not Genomics", 1: "Genomics"},
+        index={0: "Not AI", 1: "AI"},
+    )
+
+    if percent:
+        cat_counts = (cat_counts / labelled_patents.shape[0]) * 100
+        cat_counts = cat_counts.round(2)
+
+    cat_counts.index.name = None
+    cat_counts.columns.name = None
+
+    return cat_counts.to_markdown()
+
+
+VERIFIED_PATH = PROJECT_DIR / "outputs/data/patents/ai_genomics_patents_verified.csv"
+
+
+@click.command()
+@click.option("-i", "--input", default=VERIFIED_PATH)
+def run(input):
+    if type(input) != PosixPath:
+        input = PosixPath(input)
+
+    out_path = input.parent
+
+    labelled = pd.read_csv(input)
+
+    cat_counts = ai_genomics_counts(labelled)
+    with open(out_path / "ai_genomics_patents_verified_counts.md", "w") as f:
+        f.writelines(cat_counts.split("\n"))
+
+    read_full_counts = ai_genomics_read_full_patent(labelled)
+    with open(out_path / "ai_genomics_patents_read_full.md", "w") as f:
+        f.writelines(read_full_counts.split("\n"))
+
+
+if __name__ == "__main__":
+    run()

--- a/ai_genomics/utils/text.py
+++ b/ai_genomics/utils/text.py
@@ -1,0 +1,12 @@
+"""ai_genomics/utils/text.py
+
+Non-domain specific utility functions for processing strings and tokenised text data.
+"""
+
+
+def contains_non_ascii(s: str) -> bool:
+    """Flags if a string contains characters outside of the ASCII range."""
+    for c in s:
+        if ord(c) > 127:
+            return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ db-dtypes
 google-cloud-bigquery
 google-cloud-bigquery-storage
 google-api-core
+click


### PR DESCRIPTION
Closes #43. Also closes #41 as we do not need to sample as this pulls all available abstracts.

This PR adds:
* Getters to load patent publication numbers from S3 (`ai_genomics/getters/patents.py`)
* Script to add extra fields to AI in genomics patents and clean the data (`ai_genomics/pipeline/patent_data/add_fields_to_patents.py`)

Note that the duplicate `application_number` values have different `publication_number` values.

NEED TO DO:
* Set dtypes on getter to load final dataset
* Readme (will add once agreed what patents to include)
* Add a note on completeness into PR/readme (will add once agreed what patents to include)

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review
