### PR TITLE
[76] Create samples for AI Genomics datasets

### DIFF
--- a/ai_genomics/pipeline/samples/README.md
+++ b/ai_genomics/pipeline/samples/README.md
@@ -1,0 +1,3 @@
+## Making samples from the AI Genomics datasets
+
+Run `python ai_genomics/pipeline/samples/make_samples.py` to generate a csv for each of the four AI Genomics datasets: patents, OpenAlex, GtR and Crunchbase. The csvs will be saved to S3 at `inputs/ai_genomics_samples/`.

--- a/ai_genomics/pipeline/samples/make_samples.py
+++ b/ai_genomics/pipeline/samples/make_samples.py
@@ -1,0 +1,91 @@
+import pandas as pd
+from ai_genomics import bucket_name
+from ai_genomics.getters.crunchbase import get_ai_genomics_crunchbase_org_ids
+from ai_genomics.getters.data_getters import save_to_s3
+from ai_genomics.getters.gtr import get_ai_genomics_gtr_data
+from ai_genomics.getters.openalex import get_openalex_ai_genomics_works, work_abstracts
+from ai_genomics.getters.patents import get_ai_genomics_patents
+from ai_genomics.utils.crunchbase import fetch_crunchbase, parse_s3_table
+
+YEARS = range(2007, 2022)
+SAMPLE_SIZE = 100
+
+
+def openalex_abstracts_dict_to_df(openalex_abstracts: dict) -> pd.DataFrame:
+    """Converts OpenAlex abstracts into a DataFrame"""
+    return (
+        pd.DataFrame.from_dict(openalex_abstracts, orient="index")
+        .reset_index()
+        .rename(columns={"index": "work_id", 0: "abstract_text"})
+    )
+
+
+def make_ai_genomics_openalex_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+    """Returns a sample of AI Genomics OpenAlex work abstracts"""
+    oa_ai_abstracts = work_abstracts(discipline="artificial_intelligence", years=YEARS)
+    oa_genomics_abstracts = work_abstracts(discipline="genetics", years=YEARS)
+    combined_abstracts = (
+        pd.concat(
+            [
+                openalex_abstracts_dict_to_df(oa_ai_abstracts),
+                openalex_abstracts_dict_to_df(oa_genomics_abstracts),
+            ]
+        )
+        .query("abstract_text.notnull()")
+        .drop_duplicates()
+    )
+    return (
+        get_openalex_ai_genomics_works()
+        .sample(sample_size)
+        .merge(how="inner", right=combined_abstracts, on="work_id")[
+            ["work_id", "abstract_text"]
+        ]
+        .reset_index(drop=True)
+    )
+
+
+def make_ai_genomics_gtr_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+    """Returns a sample of AI Genomics Gateway to Research project abstracts"""
+    return (
+        get_ai_genomics_gtr_data("projects")[["id", "abstract_text"]]
+        .sample(sample_size)
+        .reset_index(drop=True)
+    )
+
+
+def make_ai_genomics_patent_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+    """Returns a sample of AI Genomics patent abstracts"""
+    return (
+        get_ai_genomics_patents()[["publication_number", "abstract_text"]]
+        .sample(sample_size)
+        .reset_index(drop=True)
+    )
+
+
+def make_ai_genomics_cb_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+    """Returns a sample of AI Genomics Crunchbase company descriptions"""
+    cb_orgs = parse_s3_table(fetch_crunchbase("orgs"))[
+        ["id", "long_description", "short_description"]
+    ]
+    return (
+        get_ai_genomics_crunchbase_org_ids()
+        .merge(cb_orgs, how="inner", left_on="cb_org_id", right_on="id")
+        .assign(description=lambda x: x.long_description.fillna(x.short_description))
+        .query("description.notnull()")
+        .sample(sample_size)
+        .reset_index(drop=True)[["cb_org_id", "description"]]
+    )
+
+
+if __name__ == "__main__":
+    samples = {
+        "ai_genomics_openalex_samples": make_ai_genomics_openalex_samples(),
+        "ai_genomics_gtr_samples": make_ai_genomics_gtr_samples(),
+        "ai_genomics_patent_samples": make_ai_genomics_patent_samples(),
+        "ai_genomics_cb_samples": make_ai_genomics_cb_samples(),
+    }
+
+    for sample_name, sample_df in samples.items():
+        save_to_s3(
+            bucket_name, sample_df, f"inputs/ai_genomics_samples/{sample_name}.csv"
+        )

--- a/ai_genomics/pipeline/samples/make_samples.py
+++ b/ai_genomics/pipeline/samples/make_samples.py
@@ -20,7 +20,7 @@ def openalex_abstracts_dict_to_df(openalex_abstracts: dict) -> pd.DataFrame:
     )
 
 
-def make_ai_genomics_openalex_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+def make_ai_genomics_openalex_samples(sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
     """Returns a sample of AI Genomics OpenAlex work abstracts"""
     oa_ai_abstracts = work_abstracts(discipline="artificial_intelligence", years=YEARS)
     oa_genomics_abstracts = work_abstracts(discipline="genetics", years=YEARS)
@@ -44,7 +44,7 @@ def make_ai_genomics_openalex_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
     )
 
 
-def make_ai_genomics_gtr_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+def make_ai_genomics_gtr_samples(sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
     """Returns a sample of AI Genomics Gateway to Research project abstracts"""
     return (
         get_ai_genomics_gtr_data("projects")[["id", "abstract_text"]]
@@ -53,7 +53,7 @@ def make_ai_genomics_gtr_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
     )
 
 
-def make_ai_genomics_patent_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+def make_ai_genomics_patent_samples(sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
     """Returns a sample of AI Genomics patent abstracts"""
     return (
         get_ai_genomics_patents()[["publication_number", "abstract_text"]]
@@ -62,7 +62,7 @@ def make_ai_genomics_patent_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
     )
 
 
-def make_ai_genomics_cb_samples(sample_size=SAMPLE_SIZE) -> pd.DataFrame:
+def make_ai_genomics_cb_samples(sample_size: int = SAMPLE_SIZE) -> pd.DataFrame:
     """Returns a sample of AI Genomics Crunchbase company descriptions"""
     cb_orgs = parse_s3_table(fetch_crunchbase("orgs"))[
         ["id", "long_description", "short_description"]

--- a/ai_genomics/utils/crunchbase.py
+++ b/ai_genomics/utils/crunchbase.py
@@ -21,7 +21,9 @@ def fetch_crunchbase(
     )
 
 
-def parse_s3_table(s3_object) -> pd.DataFrame:
+def parse_s3_table(
+    s3_object,
+) -> pd.DataFrame:
     """Parses an s3 object into a pandas dataframe"""
     return pipe(
         s3_object,

--- a/ai_genomics/utils/crunchbase.py
+++ b/ai_genomics/utils/crunchbase.py
@@ -5,9 +5,6 @@ import pandas as pd
 from toolz import pipe
 
 
-from ai_genomics import config
-
-
 def fetch_crunchbase(
     table_name: str,
 ) -> pd.DataFrame:
@@ -25,7 +22,7 @@ def fetch_crunchbase(
 
 
 def parse_s3_table(s3_object) -> pd.DataFrame:
-    """PParses an s3 object into a pandas dataframe"""
+    """Parses an s3 object into a pandas dataframe"""
     return pipe(
         s3_object,
         lambda _object: _object["Body"].read().decode("utf-8"),


### PR DESCRIPTION
Closes #76.

This PR adds functionality to sample data from the four AI Genomics datasets: patents, OpenAlex, GtR and Crunchbase.

Do you think this should sit in `pipeline/` or `analysis/`?

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
