### PR TITLE
Embed and cluster AI Genomics DBpedia entities

### DIFF
--- a/ai_genomics/config/entity_cluster.yaml
+++ b/ai_genomics/config/entity_cluster.yaml
@@ -1,0 +1,14 @@
+filter_entities:
+  min_entity_freq: 10
+  max_entity_freq: null
+embed:
+  model: all-MiniLM-L6-v2
+cluster:
+  k_100:
+    n_clusters: 100
+  k_200:
+    n_clusters: 200
+  k_500:
+    n_clusters: 500
+  k_1000:
+    n_clusters: 1000

--- a/ai_genomics/getters/crunchbase.py
+++ b/ai_genomics/getters/crunchbase.py
@@ -44,3 +44,18 @@ def get_crunchbase_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         bucket_name,
         "outputs/entity_extraction/cb_lookup_clean.json",
     )
+
+
+def get_crunchbase_ai_genomics_entity_groups(k: int = 500) -> pd.DataFrame:
+    """Gets a dataframe of vectors representing the presence of DBpedia entity
+    clusters in each document.
+
+    Args:
+        k (int, optional): The number of clusters. Defaults to 500.
+
+    Returns:
+        pd.DataFrame: A sparse dataframe where the index is company IDs and
+            the columns are vector dimensions (entity cluster IDs).
+    """
+    fname = f"inputs/entities/crunchbase_entity_group_vectors_k_{k}.csv"
+    return load_s3_data(bucket_name, fname)

--- a/ai_genomics/getters/entities.py
+++ b/ai_genomics/getters/entities.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from ai_genomics import bucket_name
+from ai_genomics.getters.data_getters import load_s3_data
+
+
+def get_entity_cluster_lookup(k: int = 500) -> Dict[str, int]:
+    """Gets a lookup between DBpedia entities and their entity cluster IDs.
+
+    Args:
+        k (int, optional): The number of clusters. Defaults to 500.
+
+    Returns:
+        Dict[str, int]: A lookup where keys are entity names and values are
+            cluster IDs
+    """
+    fname = f"inputs/entities/entity_groups_k_{k}.json"
+    load_s3_data(bucket_name, fname)

--- a/ai_genomics/getters/entities.py
+++ b/ai_genomics/getters/entities.py
@@ -15,4 +15,4 @@ def get_entity_cluster_lookup(k: int = 500) -> Dict[str, int]:
             cluster IDs
     """
     fname = f"inputs/entities/entity_groups_k_{k}.json"
-    load_s3_data(bucket_name, fname)
+    return load_s3_data(bucket_name, fname)

--- a/ai_genomics/getters/gtr.py
+++ b/ai_genomics/getters/gtr.py
@@ -66,3 +66,18 @@ def get_gtr_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         BUCKET_NAME,
         "outputs/entity_extraction/gtr_lookup_clean.json",
     )
+
+
+def get_gtr_ai_genomics_project_entity_groups(k: int = 500) -> pd.DataFrame:
+    """Gets a dataframe of vectors representing the presence of DBpedia entity
+    clusters in each document.
+
+    Args:
+        k (int, optional): The number of clusters. Defaults to 500.
+
+    Returns:
+        pd.DataFrame: A sparse dataframe where the index is project IDs and
+            the columns are vector dimensions (entity cluster IDs).
+    """
+    fname = f"inputs/entities/gtr_entity_group_vectors_k_{k}.csv"
+    return load_s3_data(BUCKET_NAME, fname)

--- a/ai_genomics/getters/openalex.py
+++ b/ai_genomics/getters/openalex.py
@@ -1,14 +1,13 @@
 import json
 
 import pandas as pd
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Mapping, Union
 from functools import reduce
 from toolz import pipe
 
 from ai_genomics.utils.reading import read_json
 from ai_genomics.getters.data_getters import load_s3_data
-from ai_genomics import PROJECT_DIR, logger
-
+from ai_genomics import PROJECT_DIR, logger, bucket_name
 
 OALEX_PATH = f"{PROJECT_DIR}/inputs/data/openalex"
 OALEX_OUT_PATH = f"{PROJECT_DIR}/outputs/data/openalex"

--- a/ai_genomics/getters/openalex.py
+++ b/ai_genomics/getters/openalex.py
@@ -206,3 +206,18 @@ def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         bucket_name,
         "outputs/entity_extraction/oa_lookup_clean.json",
     )
+
+
+def get_openalex_ai_genomics_works_entity_groups(k: int = 500) -> pd.DataFrame:
+    """Gets a dataframe of vectors representing the presence of DBpedia entity
+    clusters in each document.
+
+    Args:
+        k (int, optional): The number of clusters. Defaults to 500.
+
+    Returns:
+        pd.DataFrame: A sparse dataframe where the index is work IDs and
+            the columns are vector dimensions (entity cluster IDs).
+    """
+    fname = f"inputs/entities/openalex_entity_group_vectors_k_{k}.csv"
+    return load_s3_data(bucket_name, fname)

--- a/ai_genomics/getters/patents.py
+++ b/ai_genomics/getters/patents.py
@@ -104,3 +104,18 @@ def get_genomics_patents_entities() -> Mapping[str, Mapping[str, Union[str, str]
         bucket_name,
         "outputs/entity_extraction/genomics_patents_lookup_clean.json",
     )
+
+
+def get_patent_ai_genomics_entity_groups(k: int = 500) -> pd.DataFrame:
+    """Gets a dataframe of vectors representing the presence of DBpedia entity
+    clusters in each document.
+
+    Args:
+        k (int, optional): The number of clusters. Defaults to 500.
+
+    Returns:
+        pd.DataFrame: A sparse dataframe where the index is patent IDs and
+            the columns are vector dimensions (entity cluster IDs).
+    """
+    fname = f"inputs/entities/gtr_entity_group_vectors_k_{k}.csv"
+    return load_s3_data(bucket_name, fname)

--- a/ai_genomics/pipeline/entity_cluster/__init__.py
+++ b/ai_genomics/pipeline/entity_cluster/__init__.py
@@ -1,0 +1,83 @@
+from itertools import chain
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+
+from typing import Any, Dict, Mapping, Sequence
+
+from ai_genomics.utils.text_embedding import embed
+
+
+def embed_entities(
+    entities: Mapping[str, Sequence[str]],
+    model: str,
+) -> pd.DataFrame:
+    """_summary_
+
+    Args:
+        entities (Mapping[str, Mapping[str, Union[str, str]]]): Entities
+            (without scores) for a set of documents.
+        model (str): Name of a sentence transformer model.
+
+    Returns:
+        pd.DataFrame: Dataframe where rows are entities and columns are
+            embedding values.
+    """
+    entities_unique = list(set(chain(*entities.values())))
+    embeddings = embed(entities_unique, model)
+
+    return pd.DataFrame(embeddings, index=entities_unique)
+
+
+def create_entity_embedding_clusters(
+    entity_embeddings: pd.DataFrame,
+    cluster_params: Mapping[str, Any],
+) -> Dict[str, int]:
+    """Clusters entity embeddings using K means and returns a lookup between
+    entities and their cluster ID.
+
+    Args:
+        entity_embeddings (pd.DataFrame): Embeddings for a set of entities.
+        cluster_params (Mapping[str, Any]): A dictionary or other mapping of
+            kwargs to pass into the clusterer.
+
+    Returns:
+        Dict[str, int]: A lookup between entities and their cluster IDs.
+    """
+    km = KMeans(**cluster_params)
+    km.fit(entity_embeddings)
+
+    return dict(zip(entity_embeddings.index, [int(l) for l in km.labels_]))
+
+
+def create_doc_vectors(
+    entities: Mapping[str, Sequence[str]],
+    entity_to_clusters_lookup: Mapping[str, int],
+) -> pd.DataFrame:
+    """Create document vectors that represent the presence of an entity cluster
+    within a document.
+
+
+
+    Args:
+        entities (Mapping[str, Sequence[str]]): Entities (without scores) for
+            a set of documents.
+        entity_to_clusters_lookup (Mapping[str, int]): A lookup between
+            entities and their cluster.
+
+    Returns:
+        pd.DataFrame: The document vectors.
+    """
+
+    d = max(entity_to_clusters_lookup.values())
+
+    doc_vectors = []
+    for ents in entities.values():
+        entity_groups = [
+            entity_to_clusters_lookup[e]
+            for e in ents
+            if entity_to_clusters_lookup.get(e) is not None
+        ]
+        doc_vectors.append(np.np.bincount(entity_groups, minlength=d))
+
+    return pd.DataFrame(np.array(doc_vectors), index=entities.keys())

--- a/ai_genomics/pipeline/entity_cluster/__init__.py
+++ b/ai_genomics/pipeline/entity_cluster/__init__.py
@@ -57,7 +57,10 @@ def create_doc_vectors(
     """Create document vectors that represent the presence of an entity cluster
     within a document.
 
-
+    This works like a count vectorisation. The number of entities in each
+    document belonging to an entity cluster is summed. The result is a sparse
+    matrix where rows are documents and columns represent the number of times
+    an entity cluster was identified in a document.
 
     Args:
         entities (Mapping[str, Sequence[str]]): Entities (without scores) for
@@ -69,7 +72,7 @@ def create_doc_vectors(
         pd.DataFrame: The document vectors.
     """
 
-    d = max(entity_to_clusters_lookup.values())
+    d = max(entity_to_clusters_lookup.values()) + 1
 
     doc_vectors = []
     for ents in entities.values():
@@ -78,6 +81,8 @@ def create_doc_vectors(
             for e in ents
             if entity_to_clusters_lookup.get(e) is not None
         ]
-        doc_vectors.append(np.np.bincount(entity_groups, minlength=d))
+        doc_vectors.append(np.bincount(entity_groups, minlength=d))
 
-    return pd.DataFrame(np.array(doc_vectors), index=entities.keys())
+    doc_vectors = pd.DataFrame(np.array(doc_vectors), index=entities.keys())
+    doc_vectors.index.name = "id"
+    return doc_vectors

--- a/ai_genomics/pipeline/entity_cluster/create_entity_clusters.py
+++ b/ai_genomics/pipeline/entity_cluster/create_entity_clusters.py
@@ -1,0 +1,84 @@
+import json
+from toolz.dicttoolz import merge
+from toolz.functoolz import pipe
+
+from ai_genomics import PROJECT_DIR, get_yaml_config, logger
+from ai_genomics.utils.reading import make_path_if_not_exist
+
+from ai_genomics.getters.openalex import (
+    get_openalex_entities,
+    get_openalex_ai_genomics_works,
+)
+from ai_genomics.getters.patents import (
+    get_ai_genomics_patents_entities,
+    get_ai_genomics_patents,
+)
+from ai_genomics.getters.gtr import get_gtr_entities, get_ai_genomics_project_table
+from ai_genomics.getters.crunchbase import (
+    get_crunchbase_entities,
+    get_ai_genomics_crunchbase_orgs,
+)
+
+from ai_genomics.pipeline.entity_cluster import (
+    embed_entities,
+    create_entity_embedding_clusters,
+)
+from ai_genomics.utils.entities import (
+    filter_entities,
+    strip_scores,
+)
+
+
+CONFIG = get_yaml_config(PROJECT_DIR / "ai_genomics/config/entity_cluster.yaml")
+OUT_DIR = PROJECT_DIR / "inputs/entities/"
+
+
+if __name__ == "__main__":
+
+    logger.info("Fetching and merging entities.")
+    gtr_ids = list(get_ai_genomics_project_table().query("ai_genomics == True")["id"])
+    oa_ids = list(
+        get_openalex_ai_genomics_works().query("ai_genomics == True")["work_id"]
+    )
+    cb_ids = list(get_ai_genomics_crunchbase_orgs().query("ai_genom == True")["id"])
+
+    oa_entities = get_openalex_entities()
+    oa_entities = {k: oa_entities[k] for k in oa_ids}
+
+    gtr_entities = get_gtr_entities()
+    gtr_entities = {k: gtr_entities[k] for k in gtr_ids}
+
+    cb_entities = get_crunchbase_entities()
+    cb_entities = {k: cb_entities[k] for k in cb_ids}
+
+    patent_entities = get_ai_genomics_patents_entities()
+
+    entities = merge(
+        oa_entities,
+        gtr_entities,
+        cb_entities,
+        patent_entities,
+    )
+
+    logger.info("Filtering and embedding entities.")
+    entities = strip_scores(entities)
+    entities = filter_entities(
+        entities,
+        **CONFIG["filter_entities"],
+    )
+
+    embeddings = embed_entities(
+        entities,
+        **CONFIG["embed"],
+    )
+
+    make_path_if_not_exist(OUT_DIR)
+    for k, params in CONFIG["cluster"].items():
+        logger.info(f"Clustering {k} entities.")
+        cluster_lookup = create_entity_embedding_clusters(
+            embeddings,
+            params,
+        )
+
+        with open(OUT_DIR / f"entity_groups_{k}.json", "w") as f:
+            json.dump(cluster_lookup, f)

--- a/ai_genomics/pipeline/entity_cluster/create_entity_clusters.py
+++ b/ai_genomics/pipeline/entity_cluster/create_entity_clusters.py
@@ -1,4 +1,5 @@
 import json
+from sklearn import cluster
 from toolz.dicttoolz import merge
 from toolz.functoolz import pipe
 
@@ -11,17 +12,19 @@ from ai_genomics.getters.openalex import (
 )
 from ai_genomics.getters.patents import (
     get_ai_genomics_patents_entities,
-    get_ai_genomics_patents,
 )
-from ai_genomics.getters.gtr import get_gtr_entities, get_ai_genomics_project_table
+from ai_genomics.getters.gtr import (
+    get_gtr_entities,
+    get_ai_genomics_project_table,
+)
 from ai_genomics.getters.crunchbase import (
     get_crunchbase_entities,
     get_ai_genomics_crunchbase_orgs,
 )
-
 from ai_genomics.pipeline.entity_cluster import (
     embed_entities,
     create_entity_embedding_clusters,
+    create_doc_vectors,
 )
 from ai_genomics.utils.entities import (
     filter_entities,
@@ -82,3 +85,11 @@ if __name__ == "__main__":
 
         with open(OUT_DIR / f"entity_groups_{k}.json", "w") as f:
             json.dump(cluster_lookup, f)
+
+        entity_list = [oa_entities, patent_entities, gtr_entities, cb_entities]
+        dataset_names = ["openalex", "patent", "gtr", "crunchbase"]
+
+        for ents, name in zip(entity_list, dataset_names):
+            ents = strip_scores(ents)
+            doc_vecs = create_doc_vectors(ents, cluster_lookup)
+            doc_vecs.to_csv(OUT_DIR / f"{name}_entity_group_vectors_{k}.csv")

--- a/ai_genomics/utils/entities.py
+++ b/ai_genomics/utils/entities.py
@@ -1,0 +1,50 @@
+"""Utilities for working with entities."""
+from collections import Counter
+from itertools import chain
+import numpy as np
+
+from typing import Mapping, Optional, Union
+
+
+def strip_scores(entities):
+    return {k: [e[0] for e in v] for k, v in entities.items()}
+
+
+def filter_entities(
+    entities: Mapping[str, Mapping[str, Union[str, str]]],
+    min_entity_freq: Optional[Union[int, float]] = None,
+    max_entity_freq: Optional[Union[int, float]] = None,
+) -> Mapping[str, Mapping[str, Union[str, str]]]:
+    """_summary_
+
+    Args:
+        entities (Mapping[str, Mapping[str, Union[str, str]]]): DBpedia entities
+            for a set of documents without scores.
+        min_entity_freq (Optional[Union[int, float]], optional): The minimum
+            frequency for an entity. Any entities with a frequency below this
+            will be filtered. Defaults to None.
+        max_entity_freq (Optional[Union[int, float]], optional): The maximum
+            frequency for an entity. Any entities with a frequency above this
+            will be filtered. Defaults to None.
+
+    Returns:
+        Mapping[str, Mapping[str, Union[str, str]]]: Filtered entities.
+    """
+    entity_freqs = Counter(chain(*entities.values()))
+    entity_freq_low = min(entity_freqs.values())
+    entity_freq_high = max(entity_freqs.values())
+
+    if type(min_entity_freq) == float:
+        min_entity_freq = np.round(min_entity_freq * entity_freq_high)
+    elif min_entity_freq is None:
+        min_entity_freq = entity_freq_low
+
+    if type(max_entity_freq) == float:
+        max_entity_freq = np.round(max_entity_freq * entity_freq_high)
+    elif max_entity_freq is None:
+        max_entity_freq = entity_freq_high
+
+    return {
+        k: [e for e in v if min_entity_freq <= entity_freqs[e] <= max_entity_freq]
+        for k, v in entities.items()
+    }

--- a/ai_genomics/utils/entities.py
+++ b/ai_genomics/utils/entities.py
@@ -7,6 +7,8 @@ from typing import Mapping, Optional, Union
 
 
 def strip_scores(entities):
+    """Strips the scores from DBpedia entities to leave only a lookup between
+    documents and entity tags."""
     return {k: [e[0] for e in v] for k, v in entities.items()}
 
 

--- a/ai_genomics/utils/entities.py
+++ b/ai_genomics/utils/entities.py
@@ -22,27 +22,29 @@ def filter_entities(
             for a set of documents without scores.
         min_entity_freq (Optional[Union[int, float]], optional): The minimum
             frequency for an entity. Any entities with a frequency below this
-            will be filtered. Defaults to None.
+            will be filtered. If a float is passed, the mininum frequency will
+            be the value at this percentile in the frequency distribution.
+            Defaults to None.
         max_entity_freq (Optional[Union[int, float]], optional): The maximum
             frequency for an entity. Any entities with a frequency above this
-            will be filtered. Defaults to None.
+            will be filtered. If a float is passed, the maximum frequency will
+            be the value at this percentile in the frequency distribution.
+            Defaults to None.
 
     Returns:
         Mapping[str, Mapping[str, Union[str, str]]]: Filtered entities.
     """
     entity_freqs = Counter(chain(*entities.values()))
-    entity_freq_low = min(entity_freqs.values())
-    entity_freq_high = max(entity_freqs.values())
 
     if type(min_entity_freq) == float:
-        min_entity_freq = np.round(min_entity_freq * entity_freq_high)
+        min_entity_freq = np.percentile(list(entity_freqs.values()), min_entity_freq)
     elif min_entity_freq is None:
-        min_entity_freq = entity_freq_low
+        min_entity_freq = min(entity_freqs.values())
 
     if type(max_entity_freq) == float:
-        max_entity_freq = np.round(max_entity_freq * entity_freq_high)
+        max_entity_freq = np.percentile(list(entity_freqs.values()), max_entity_freq)
     elif max_entity_freq is None:
-        max_entity_freq = entity_freq_high
+        max_entity_freq = max(entity_freqs.values())
 
     return {
         k: [e for e in v if min_entity_freq <= entity_freqs[e] <= max_entity_freq]

--- a/ai_genomics/utils/reading.py
+++ b/ai_genomics/utils/reading.py
@@ -21,3 +21,15 @@ def fetch_s3(s3_path) -> Union[pd.DataFrame, Dict]:
     bucket = s3.Bucket("ai-genomics")
     obj = bucket.Object(s3_path)
     return pd.read_csv(obj.get()["Body"])
+
+
+def _convert_str_to_pathlib_path(path: Union[pathlib.Path, str]) -> pathlib.Path:
+    """Converts a path written as a string to pathlib format"""
+    return pathlib.Path(path) if type(path) is str else path
+
+
+def make_path_if_not_exist(path: Union[pathlib.Path, str]):
+    """Check if path exists, if it does not exist then create it"""
+    path = _convert_str_to_pathlib_path(path)
+    if not path.exists():
+        path.mkdir(parents=True)

--- a/ai_genomics/utils/text.py
+++ b/ai_genomics/utils/text.py
@@ -1,0 +1,9 @@
+import re
+
+
+def strip_punct(s: str) -> str:
+    """Strips punctuation from acronyms."""
+    remove_chars = r"[,|/|\?|\(|\)|\:|\;|\.]"
+    space_chars = r"[\-|_|]"
+    stripped = re.sub(remove_chars, "", s)
+    return re.sub(space_chars, " ", stripped)

--- a/ai_genomics/utils/text_embedding.py
+++ b/ai_genomics/utils/text_embedding.py
@@ -1,0 +1,30 @@
+import numpy as np
+from sentence_transformers import SentenceTransformer
+from toolz.itertoolz import partition_all
+
+from numpy.typing import NDArray
+from typing import Optional, Sequence
+
+
+def embed(
+    texts: Sequence[str],
+    model: str,
+    chunk_size: Optional[int] = None,
+) -> NDArray:
+    """Fetches a transformer model and applies it to a sequence of texts to
+    generate text embeddings.
+
+    Args:
+        texts (Sequence[str]): A sequence of texts to embed.
+        model (str): A text transformer model from https://www.sbert.net/.
+        chunk_size (int): If specified, the sequence of texts will be split
+            into chunks of this size and embedded sequentially. Only needed
+            if memory limits are an issue.
+
+    Returns:
+        NDArray: Embeddings of the texts wher m is the number of texts and n is
+        the dimension of a single embeddings, which will depend on the specific
+        transformer used.
+    """
+    model = SentenceTransformer(model)
+    return model.encode(texts)


### PR DESCRIPTION
This adds utils for embedding and semantically clustering DBpedia entities as well as a pipeline to produce clusters (or macro entities) at various levels of granularity.

The main pipeline can be run with `python ai_genomics/pipeline/entity_cluster/create_entity_clusters.py`

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
