### PR TITLE
add validation flow

### DIFF
--- a/ai_genomics/pipeline/openalex/add_validator_openalex_concepts.py
+++ b/ai_genomics/pipeline/openalex/add_validator_openalex_concepts.py
@@ -1,0 +1,73 @@
+from metaflow import FlowSpec, S3, step, Parameter, retry, batch
+
+import json
+import pandas as pd
+
+import json
+import pandas as pd
+import numpy as np
+
+from ai_genomics import PROJECT_DIR, bucket_name
+from ai_genomics.utils.reading import read_json
+from ai_genomics.getters.data_getters import load_s3_data, save_to_s3
+
+
+class ValidatorOpenAlexConceptsFlow(FlowSpec):
+    production = Parameter("production", help="Run in production?", default=False)
+
+    @step
+    def start(self):
+        """
+        Starts the flow.
+        """
+        concepts = pd.read_parquet(
+            f"{PROJECT_DIR}/outputs/openalex/openalex_concepts.parquet"
+        )
+        print("Concepts Loaded!")
+        all_concepts = load_s3_data(bucket_name, "inputs/openalex/all_oa_concepts.csv")
+        threshold = 0.0
+        concepts = concepts[concepts["score"] > threshold]
+        concepts_with_scope = concepts.merge(
+            all_concepts, how="left", left_on="display_name", right_on="display_name"
+        )
+        concepts_with_scope["Scope"] = (
+            concepts_with_scope["Scope"]
+            .replace("In scope", 3)
+            .replace("Tangential", 2)
+            .replace("Not in scope", 1)
+            .fillna(0)
+        )
+        grouped_concepts_with_scope = (
+            concepts_with_scope.groupby("doc_id").agg({"Scope": max}).reset_index()
+        )
+        grouped_concepts_with_scope["genomics_in_scope"] = np.where(
+            grouped_concepts_with_scope["Scope"] == 3, True, False
+        )
+        grouped_concepts_with_scope["genomics_tangential"] = np.where(
+            grouped_concepts_with_scope["Scope"] == 2, True, False
+        )
+        grouped_concepts_with_scope["genomics_not_in_scope"] = np.where(
+            grouped_concepts_with_scope["Scope"] == 1, True, False
+        )
+        all_works = load_s3_data(bucket_name, "outputs/openalex/openalex_works.csv")
+        all_works = all_works.merge(
+            grouped_concepts_with_scope,
+            how="left",
+            left_on="work_id",
+            right_on="doc_id",
+        )
+        save_to_s3(
+            bucket_name, all_works, "outputs/openalex/openalex_works_validated.csv"
+        )
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        Ends the flow.
+        """
+        pass
+
+
+if __name__ == "__main__":
+    ValidatorOpenAlexConceptsFlow()


### PR DESCRIPTION
This PR adds an extra stage to flag works as in scope, tangential, or out of scope based on the concept validation exercise.

How this works:
1. A csv of results of the validation exercise should be saved to `inputs/openalex/all_oa_concepts.csv`
2. The flow will load work -> concept link data, as well as the above csv of results
3. Concepts below a definable threshold will be dropped
4. Concepts will be mapped to the Scope type from the document, with a numeric reference: 3 for in scope, 2 for tangential, 1 for not in scope and 0 for not in csv (i.e. all other concepts)
5. The work -> concept link table is grouped by works, aggregating by the max of the numeric reference
6. Based on the above max (representing the closest represented concept to "In Scope"), the label is mapped back onto the grouped df, and columns generated for `genomics_in_scope`, `genomics_not_in_scope`, and `genetics_tangential`
7. The works dataset is read, and the above merged, before saving to S3

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
