### PR TITLE
Change dir for manual cluster names

### DIFF
--- a/ai_genomics/getters/clusters.py
+++ b/ai_genomics/getters/clusters.py
@@ -70,7 +70,7 @@ def get_doc_cluster_names(
 def get_doc_cluster_interp() -> Dict[int, str]:
     """Returns interpretable doc cluster names"""
 
-    cluster_names = "inputs/data/cluster_names.csv"
+    cluster_names = "outputs/data/cluster.csv"
 
     if (PROJECT_DIR / cluster_names).exists():
         data = read_csv(f"{PROJECT_DIR}/{cluster_names}")


### PR DESCRIPTION
Changed cluster name lookup to

```
cluster,name
0,Stratification and therapy
1,Diagnosis
2,Evolution
3,Neurology
4,Population genetics
5,NA
6,Computational
7,Association studies
8,Disease prediction
9,Metagenomics
10,Proteins
11,Transcriptomics
12,Molecule interactions
13,Association studies
14,Inheritance studies
15,NA
16,Sequencing
17,NA 
18,Epidemiology
19,Prenatal
```

Updated lookup getter (ai_genomics.getters.cluster.get_doc_cluster_interp) to new file location.
